### PR TITLE
Statically pin to 1.22.4 Use stable version of Go compatible with cos…

### DIFF
--- a/install-go.sh
+++ b/install-go.sh
@@ -35,7 +35,9 @@ esac
 [ -z "$GOPATH" ] && GOPATH="$HOME/go"
 
 # Automatically fetch the latest Go version for this platform
-VERSION=$(curl -s https://go.dev/dl/ | grep "$PLATFORM.tar.gz" | sed -E "s/.*go([0-9.]+)\.$PLATFORM\.tar\.gz.*/\1/" | head -n 1)
+# VERSION=$(curl -s https://go.dev/dl/ | grep "$PLATFORM.tar.gz" | sed -E "s/.*go([0-9.]+)\.$PLATFORM\.tar\.gz.*/\1/" | head -n 1)
+
+VERSION=1.22.4
 
 # Handle CLI options
 print_help() {


### PR DESCRIPTION
…movisor sdk versions installed - otherwise 1.24.5 gets installed and it will result in failure to install cosmovisor during node setup script